### PR TITLE
Use `straight.el` for package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 eln-cache/
+straight/

--- a/early-init.el
+++ b/early-init.el
@@ -58,3 +58,24 @@
 ;; ---------------------------------
 
 (set-face-attribute 'default nil :background "#000000" :foreground "#FFFFFF")
+
+
+
+
+;; ---------------------------------------------------------------------
+;;; Package Management
+;; -------------------
+;; Only one thing should be here. I only wrote this description so the
+;; formatting would be consistent. It's a useless comment. Something
+;; something package management.
+;; ---------------------------------------------------------------------
+
+;; ---------------------------------
+;; Disable package manager
+;; -----------------------
+;; Disable the built-in package
+;; manager (`package.el'), because
+;; MMOSMacs will be using
+;; `straight.el'
+;; ---------------------------------
+(setq package-enable-at-startup nil)

--- a/init.el
+++ b/init.el
@@ -31,6 +31,20 @@
   (load bootstrap-file nil 'nomessage))
 
 
+;; ---------------------------------
+;; Don't load outdated code
+;; ------------------------
+;; MMOSMacs is under highly active
+;; development and undergoes
+;; freuqent changes. The newest code
+;; should always be loaded
+;; ---------------------------------
+
+;; if a `.el' file is newer than its corresponding `.elc', load the `.el'
+(setq load-prefer-newer t)
+
+
+
 
 ;; ---------------------------------------------------------------------
 ;;; File Management

--- a/init.el
+++ b/init.el
@@ -17,6 +17,7 @@
 ;; provided by `straight.el'. Dont
 ;; ask me what it does.
 ;; ---------------------------------
+
 (defvar bootstrap-version)
 (let ((bootstrap-file
        (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))

--- a/init.el
+++ b/init.el
@@ -5,6 +5,34 @@
 
 
 ;; ---------------------------------------------------------------------
+;;; Package Management
+;; -----------------------------------
+;; MMOSMacs uses `straight.el' for package management.
+;; ---------------------------------------------------------------------
+
+;; ---------------------------------
+;; Bootstrap `straight.el'
+;; -----------------------
+;; This is some pre-written magic
+;; provided by `straight.el'. Dont
+;; ask me what it does.
+;; ---------------------------------
+(defvar bootstrap-version)
+(let ((bootstrap-file
+       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+      (bootstrap-version 6))
+  (unless (file-exists-p bootstrap-file)
+    (with-current-buffer
+        (url-retrieve-synchronously
+         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
+         'silent 'inhibit-cookies)
+      (goto-char (point-max))
+      (eval-print-last-sexp)))
+  (load bootstrap-file nil 'nomessage))
+
+
+
+;; ---------------------------------------------------------------------
 ;;; File Management
 ;; ----------------
 ;; Everything to do with file or directory management goes here.


### PR DESCRIPTION
Per RFC #5, this adds `straight.el` for package management. Additionally, it prevents MMOSMacs from loading outdated code.